### PR TITLE
Fix CardTitle ref element type

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -29,7 +29,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3


### PR DESCRIPTION
## Summary
- fix incorrect ref element types in CardTitle

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68433c2bef38832ea051b17331bcdbff