### PR TITLE
Update minSpeed reset

### DIFF
--- a/src/app/playground/bouncing-pixels/page.tsx
+++ b/src/app/playground/bouncing-pixels/page.tsx
@@ -148,7 +148,7 @@ export default function BouncingPixels() {
     setPixelCount(80);
     setExplosionForce(10);
     setRecoveryRate(0.05);
-    setMinSpeed(0.7);
+    setMinSpeed(0.5);
     setPixels(generatePixels(80));
   };
 


### PR DESCRIPTION
## Summary
- reset minSpeed to `0.5` in Bouncing Pixels reset handler

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433e4dd750832ea6bc64cc2f839510