### PR TITLE
Update metadata wording

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import Navbar from "@/components/Navbar";
 
 export const metadata: Metadata = {
   title: "Playground",
-  description: "A nice place to play with Next.JS Concepts",
+  description: "A nice place to play with Next.js Concepts",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- fix capitalization of "Next.js" in the layout metadata

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433e481864832eaab0deb9c21ffc9d